### PR TITLE
Make notifications only appear when message has length greater than 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ To use the notification API, use the following commands anywhere in your code:
 
 	$.FancyNotifications.notice("This is a notice message.");
 	
+
+You can add automatic flash notifications to your layouts by adding this to your layouts:
+
+	$.FancyNotifications.error("<%= flash[:error] %>");
+	$.FancyNotifications.alert("<%= flash[:alert] %>");
+	$.FancyNotifications.notice("<%= flash[:notice] %>");
 	
+Messages will only appear when a flash exists.
+
 
 Requirements
 ------------

--- a/lib/jquery.fancy-notifications.css
+++ b/lib/jquery.fancy-notifications.css
@@ -22,7 +22,6 @@
  font-size:1.3em;
  position:fixed;
  top:0;
- height:1.3em;
  left:0;
  z-index:10000;
 }

--- a/lib/jquery.fancy-notifications.js
+++ b/lib/jquery.fancy-notifications.js
@@ -46,15 +46,17 @@
   };
 
   $.FancyNotifications.showMessage = function(type,message){
-    var $div = $("<div></div>");
-	$div.attr("class","flash");
-	$div.attr("id", "flash_"+type);
-	$div.hide();
-	$div.html(message);
+    if(message && message.length > 0){
+      var $div = $("<div></div>");
+	  $div.attr("class","flash");
+	  $div.attr("id", "flash_"+type);
+	  $div.hide();
+	  $div.html(message);
 
-	$('body').prepend($div);
+	  $('body').prepend($div);
 
-	setupNotificationBehavior();
+	  setupNotificationBehavior();
+    }
   };
   
   $.FancyNotifications.close = function(){


### PR DESCRIPTION
This allows you to set up automated notifications by just passing in "<%= flash[:error] %>" which when empty have length 0 and won't appear.
